### PR TITLE
Restrict Admin Status Update to Super Users Only

### DIFF
--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -225,23 +225,7 @@ export async function updatedTeamUser(
   payload: UpdateTeamUserPayload,
   claims: JWT
 ): Promise<Result<Team>> {
-  const team = await prisma.team.findFirst({
-    select: {
-      users: {
-        select: {
-          userId: true,
-          isAdmin: true,
-        },
-      },
-    },
-    where: {
-      id: teamId,
-    },
-  });
-
-  const isAdmin = isAdminTeam(claims, team);
-
-  if (!isAdmin) {
+  if (!claims.isSuper) {
     return {
       data: null,
       message: "user does not have access to update team users",


### PR DESCRIPTION
#### Description
This pull request addresses an issue where the update of admin status was not correctly restricted to super users. The fix ensures that only users with super user privileges can update the admin status, improving security and adhering to role-based access control guidelines.

#### Changes include:
- Corrected logic to allow only super users to update admin status.
- Added necessary checks to ensure role verification before status updates.