### PR TITLE
Fix get user by email with insensitive

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -4,9 +4,12 @@ import { generateToken } from "@/utils/jwt";
 import { getUserInfo } from "@/services/sso";
 
 const login = async (email: string, password: string): Promise<Result<any>> => {
-  const user = await prisma.user.findUnique({
+  const user = await prisma.user.findFirst({
     where: {
-      email: email,
+      email: {
+        equals: email,
+        mode: "insensitive",
+      },
     },
   });
 
@@ -42,9 +45,12 @@ const login = async (email: string, password: string): Promise<Result<any>> => {
 const loginSso = async (tokenSso: string): Promise<Result<any>> => {
   const userSso = await getUserInfo(tokenSso);
 
-  const user = await prisma.user.findUnique({
+  const user = await prisma.user.findFirst({
     where: {
-      email: userSso.email,
+      email: {
+        equals: userSso.email,
+        mode: "insensitive",
+      },
     },
   });
 


### PR DESCRIPTION
This pull request includes changes to the `src/services/auth.ts` file to improve the user login functionality by making email matching case-insensitive. The most important changes are listed below:

Improvements to user login functionality:

* [`src/services/auth.ts`](diffhunk://#diff-1e4285f62959d16bf21c21ca382130a7ef3675bcc812a0a100e8fd06251be758L7-R12): Changed the `prisma.user.findUnique` method to `prisma.user.findFirst` for both the `login` and `loginSso` functions to enhance the search capabilities. [[1]](diffhunk://#diff-1e4285f62959d16bf21c21ca382130a7ef3675bcc812a0a100e8fd06251be758L7-R12) [[2]](diffhunk://#diff-1e4285f62959d16bf21c21ca382130a7ef3675bcc812a0a100e8fd06251be758L45-R53)
* [`src/services/auth.ts`](diffhunk://#diff-1e4285f62959d16bf21c21ca382130a7ef3675bcc812a0a100e8fd06251be758L7-R12): Modified the email matching criteria to be case-insensitive by using the `equals` operator with the `mode: "insensitive"` option in both the `login` and `loginSso` functions. [[1]](diffhunk://#diff-1e4285f62959d16bf21c21ca382130a7ef3675bcc812a0a100e8fd06251be758L7-R12) [[2]](diffhunk://#diff-1e4285f62959d16bf21c21ca382130a7ef3675bcc812a0a100e8fd06251be758L45-R53)